### PR TITLE
Add Google Sheets-backed record inventory search

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,40 @@
-# RunnersCalculator
-RunnersCalculator
+# Record Inventory
+
+This project demonstrates how to build a small inventory system for analog records.
+Data is retrieved from a Google Spreadsheet, saved into a SQLite database, and
+made searchable through a small Flask web application.
+
+## Setup
+
+1. Create a Google service account and download its JSON credentials file.
+2. Share your Google Sheet containing record data with the service account.
+3. Set environment variables:
+   - `SHEET_ID`: ID of the Google Sheet (found in its URL).
+   - `GOOGLE_APPLICATION_CREDENTIALS`: path to the service account JSON file.
+   - `DB_PATH`: location for the SQLite database (defaults to `records.db`).
+   - `WORKSHEET`: worksheet name within the sheet (defaults to `Sheet1`).
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Fetching data
+
+Run the fetch script to populate the database from the spreadsheet:
+
+```bash
+python fetch_records.py
+```
+
+## Starting the web server
+
+After the database has data, start the Flask app:
+
+```bash
+python server.py
+```
+
+Open `http://localhost:5000` in a browser and use the search field to look up
+records by title or artist.

--- a/fetch_records.py
+++ b/fetch_records.py
@@ -1,0 +1,36 @@
+"""Fetch analog record data from Google Sheets and store in SQLite."""
+
+from __future__ import annotations
+
+import os
+from typing import List, Dict
+
+import gspread
+from google.oauth2.service_account import Credentials
+
+import records_db
+
+SCOPES = ["https://www.googleapis.com/auth/spreadsheets.readonly"]
+
+
+def fetch_sheet_records(sheet_id: str, worksheet: str, creds_path: str) -> List[Dict[str, str]]:
+    """Retrieve rows from a Google Sheet as a list of dicts."""
+    creds = Credentials.from_service_account_file(creds_path, scopes=SCOPES)
+    client = gspread.authorize(creds)
+    sheet = client.open_by_key(sheet_id).worksheet(worksheet)
+    return sheet.get_all_records()
+
+
+def main() -> None:
+    sheet_id = os.environ["SHEET_ID"]
+    worksheet = os.environ.get("WORKSHEET", "Sheet1")
+    creds_path = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS", "service_account.json")
+    db_path = os.environ.get("DB_PATH", "records.db")
+
+    records = fetch_sheet_records(sheet_id, worksheet, creds_path)
+    records_db.init_db(db_path)
+    records_db.upsert_records(records, db_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/records_db.py
+++ b/records_db.py
@@ -1,0 +1,66 @@
+"""Database helper functions for record inventory."""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Dict, Iterable, List
+
+def init_db(db_path: str) -> None:
+    """Create the records table if it doesn't already exist."""
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS records (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            title TEXT,
+            artist TEXT,
+            label TEXT,
+            year TEXT,
+            catalog TEXT
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def upsert_records(records: Iterable[Dict[str, str]], db_path: str) -> None:
+    """Insert records from an iterable of dictionaries."""
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    for rec in records:
+        cur.execute(
+            """
+            INSERT INTO records (title, artist, label, year, catalog)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (
+                rec.get("title"),
+                rec.get("artist"),
+                rec.get("label"),
+                rec.get("year"),
+                rec.get("catalog"),
+            ),
+        )
+    conn.commit()
+    conn.close()
+
+
+def search_records(query: str, db_path: str) -> List[Dict[str, str]]:
+    """Search for records where title or artist matches the query."""
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    cur = conn.cursor()
+    like = f"%{query}%"
+    cur.execute(
+        """
+        SELECT title, artist, label, year, catalog
+        FROM records
+        WHERE title LIKE ? OR artist LIKE ?
+        """,
+        (like, like),
+    )
+    rows = [dict(row) for row in cur.fetchall()]
+    conn.close()
+    return rows

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+Flask
+gspread
+google-auth
+pytest

--- a/server.py
+++ b/server.py
@@ -1,0 +1,22 @@
+"""Simple Flask app to search record inventory."""
+
+from __future__ import annotations
+
+import os
+from flask import Flask, request, render_template
+
+import records_db
+
+app = Flask(__name__)
+DB_PATH = os.environ.get("DB_PATH", "records.db")
+
+
+@app.route("/", methods=["GET"])
+def index():
+    query = request.args.get("q", "")
+    results = records_db.search_records(query, DB_PATH) if query else []
+    return render_template("index.html", query=query, results=results)
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<title>Record Inventory</title>
+<h1>Record Inventory</h1>
+<form method="get">
+  <input type="text" name="q" placeholder="Search by title or artist" value="{{ query }}">
+  <input type="submit" value="Search">
+</form>
+<ul>
+{% for record in results %}
+  <li>{{ record['artist'] }} - {{ record['title'] }} ({{ record['year'] }})</li>
+{% else %}
+  {% if query %}
+    <li>No results</li>
+  {% endif %}
+{% endfor %}
+</ul>

--- a/tests/test_records_db.py
+++ b/tests/test_records_db.py
@@ -1,0 +1,35 @@
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+# Ensure project root is on path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import records_db
+
+
+def test_init_and_search():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        records_db.init_db(db_path)
+        sample = [
+            {
+                "title": "Blue Train",
+                "artist": "John Coltrane",
+                "label": "Blue Note",
+                "year": "1957",
+                "catalog": "BN 1577",
+            },
+            {
+                "title": "Kind of Blue",
+                "artist": "Miles Davis",
+                "label": "Columbia",
+                "year": "1959",
+                "catalog": "CL 1355",
+            },
+        ]
+        records_db.upsert_records(sample, db_path)
+        result = records_db.search_records("Coltrane", db_path)
+        assert result[0]["artist"] == "John Coltrane"
+        assert len(records_db.search_records("Miles", db_path)) == 1


### PR DESCRIPTION
## Summary
- add database helpers to store analog record data in SQLite
- script to fetch records from Google Sheets and populate the database
- simple Flask web app with search form for inventory lookup
- basic test verifying database insert and search

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Flask)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6838e528c832090a386ac9ea331ed